### PR TITLE
Refactor audio tests to avoid Robolectric network dependency

### DIFF
--- a/SaidIt/build.gradle.kts
+++ b/SaidIt/build.gradle.kts
@@ -81,6 +81,7 @@ dependencies {
     testImplementation(libs.mockito.core)
     testImplementation(libs.mockito.kotlin)
     testImplementation(libs.robolectric)
+    testRuntimeOnly(libs.robolectric.android.all)
     testImplementation(libs.coroutines.test)
     // Hilt testing for Robolectric/JUnit
     testImplementation(libs.hilt.android.testing)

--- a/SaidIt/src/test/kotlin/eu/mrogalski/android/ViewsTest.kt
+++ b/SaidIt/src/test/kotlin/eu/mrogalski/android/ViewsTest.kt
@@ -8,12 +8,17 @@ import android.widget.TextView
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
 import org.mockito.Mockito.*
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 
 /**
  * Comprehensive unit tests for Views utility functions.
  * Tests both legacy Java-compatible methods and modern Kotlin extensions.
  */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
 class ViewsTest {
     
     private lateinit var rootViewGroup: ViewGroup

--- a/SaidIt/src/test/kotlin/eu/mrogalski/saidit/NotifyFileReceiverTest.kt
+++ b/SaidIt/src/test/kotlin/eu/mrogalski/saidit/NotifyFileReceiverTest.kt
@@ -30,6 +30,7 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import org.robolectric.shadows.ShadowApplication
+import org.robolectric.Shadows
 import org.robolectric.shadows.ShadowNotificationManager
 
 /**
@@ -78,7 +79,7 @@ class NotifyFileReceiverTest {
         receiver.onSuccess(testUri)
         
         // Then
-        val shadowNotificationManager = ShadowNotificationManager.shadowOf(
+        val shadowNotificationManager = Shadows.shadowOf(
             context.getSystemService(Context.NOTIFICATION_SERVICE) as android.app.NotificationManager
         )
         val notifications = shadowNotificationManager.allNotifications
@@ -97,7 +98,7 @@ class NotifyFileReceiverTest {
         receiver.onSuccess(testUri)
         
         // Then
-        val shadowNotificationManager = ShadowNotificationManager.shadowOf(
+        val shadowNotificationManager = Shadows.shadowOf(
             context.getSystemService(Context.NOTIFICATION_SERVICE) as android.app.NotificationManager
         )
         val notifications = shadowNotificationManager.allNotifications
@@ -117,7 +118,7 @@ class NotifyFileReceiverTest {
         receiver.onSuccess(testUri)
         
         // Then
-        val shadowNotificationManager = ShadowNotificationManager.shadowOf(
+        val shadowNotificationManager = Shadows.shadowOf(
             context.getSystemService(Context.NOTIFICATION_SERVICE) as android.app.NotificationManager
         )
         val notification = shadowNotificationManager.getNotification(43)
@@ -134,7 +135,7 @@ class NotifyFileReceiverTest {
         receiver.onFailure(exception)
         
         // Then - no exception thrown, no notification posted
-        val shadowNotificationManager = ShadowNotificationManager.shadowOf(
+        val shadowNotificationManager = Shadows.shadowOf(
             context.getSystemService(Context.NOTIFICATION_SERVICE) as android.app.NotificationManager
         )
         val notifications = shadowNotificationManager.allNotifications
@@ -224,7 +225,7 @@ class NotifyFileReceiverTest {
         
         // Test without permission
         receiver.onSuccess(testUri)
-        var shadowNotificationManager = ShadowNotificationManager.shadowOf(
+        var shadowNotificationManager = Shadows.shadowOf(
             context.getSystemService(Context.NOTIFICATION_SERVICE) as android.app.NotificationManager
         )
         assertEquals(0, shadowNotificationManager.allNotifications.size)
@@ -232,7 +233,7 @@ class NotifyFileReceiverTest {
         // Grant permission and test again
         ShadowApplication.getInstance().grantPermissions(Manifest.permission.POST_NOTIFICATIONS)
         receiver.onSuccess(testUri)
-        shadowNotificationManager = ShadowNotificationManager.shadowOf(
+        shadowNotificationManager = Shadows.shadowOf(
             context.getSystemService(Context.NOTIFICATION_SERVICE) as android.app.NotificationManager
         )
         assertEquals(1, shadowNotificationManager.allNotifications.size)
@@ -279,7 +280,7 @@ class NotifyFileReceiverTest {
         receiver.onSuccess(testUri2)
         
         // Then - only one notification because same ID is used
-        val shadowNotificationManager = ShadowNotificationManager.shadowOf(
+        val shadowNotificationManager = Shadows.shadowOf(
             context.getSystemService(Context.NOTIFICATION_SERVICE) as android.app.NotificationManager
         )
         val notification = shadowNotificationManager.getNotification(43)

--- a/SaidIt/src/test/kotlin/eu/mrogalski/saidit/SaidItFragmentTest.kt
+++ b/SaidIt/src/test/kotlin/eu/mrogalski/saidit/SaidItFragmentTest.kt
@@ -16,6 +16,8 @@ import com.google.android.material.button.MaterialButtonToggleGroup
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.textview.MaterialTextView
 import eu.mrogalski.android.TimeFormat
+import eu.mrogalski.saidit.NotifyFileReceiver
+import eu.mrogalski.saidit.PromptFileReceiver
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -26,6 +28,7 @@ import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.MockedStatic
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
 
 /**
@@ -245,7 +248,7 @@ class SaidItFragmentTest {
         val fileName = "test_recording.mp4"
         
         // When
-        val notification = fragment.buildNotificationForFile(appContext, fileUri, fileName)
+        val notification = NotifyFileReceiver.buildNotificationForFile(appContext, fileUri, fileName)
         
         // Then
         assert(notification != null)
@@ -257,10 +260,10 @@ class SaidItFragmentTest {
         // Given - Use Robolectric's application context
         val appContext = RuntimeEnvironment.getApplication()
         val mockUri = mock(Uri::class.java)
-        val receiver = fragment.NotifyFileReceiver(appContext)
+        val receiver = NotifyFileReceiver(appContext)
 
         // Grant POST_NOTIFICATIONS permission so NotificationManagerCompat.notify() is reachable
-        org.robolectric.Shadows.shadowOf(appContext).grantPermissions(android.Manifest.permission.POST_NOTIFICATIONS)
+        shadowOf(appContext).grantPermissions(android.Manifest.permission.POST_NOTIFICATIONS)
         
         // Mock static method using Mockito
         mockStatic(NotificationManagerCompat::class.java).use { mockedStatic ->
@@ -278,7 +281,7 @@ class SaidItFragmentTest {
     @Test
     fun `NotifyFileReceiver onFailure does nothing`() {
         // Given
-        val receiver = fragment.NotifyFileReceiver(mockContext)
+        val receiver = NotifyFileReceiver(mockContext)
         val exception = Exception("Test failure")
         
         // When
@@ -296,7 +299,7 @@ class SaidItFragmentTest {
         `when`(mockActivity.isFinishing).thenReturn(false)
         `when`(mockDialog.isShowing).thenReturn(true)
         
-        val receiver = fragment.PromptFileReceiver(mockActivity, mockDialog)
+        val receiver = PromptFileReceiver(mockActivity, mockDialog)
         
         // Mock the dialog builder chain
         val mockBuilder = mock(MaterialAlertDialogBuilder::class.java)
@@ -320,7 +323,7 @@ class SaidItFragmentTest {
         val mockUri = mock(Uri::class.java)
         `when`(mockActivity.isFinishing).thenReturn(true)
         
-        val receiver = fragment.PromptFileReceiver(mockActivity)
+        val receiver = PromptFileReceiver(mockActivity)
         
         // When
         receiver.onSuccess(mockUri)
@@ -335,7 +338,7 @@ class SaidItFragmentTest {
         val exception = Exception("Test error")
         `when`(mockActivity.isFinishing).thenReturn(false)
         
-        val receiver = fragment.PromptFileReceiver(mockActivity)
+        val receiver = PromptFileReceiver(mockActivity)
         
         // Mock the dialog builder
         val mockBuilder = mock(MaterialAlertDialogBuilder::class.java)

--- a/audio/build.gradle.kts
+++ b/audio/build.gradle.kts
@@ -38,8 +38,7 @@ dependencies {
     implementation("androidx.appcompat:appcompat:1.6.1")
     implementation("com.google.android.material:material:1.8.0")
     testImplementation("junit:junit:4.13.2")
-    testImplementation("org.robolectric:robolectric:4.11.1")
-    testImplementation("androidx.test:core:1.5.0")
+    testImplementation("io.mockk:mockk:1.13.13")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
 }

--- a/audio/src/main/kotlin/com/siya/epistemophile/audio/AudioPlayer.kt
+++ b/audio/src/main/kotlin/com/siya/epistemophile/audio/AudioPlayer.kt
@@ -3,17 +3,21 @@ package com.siya.epistemophile.audio
 import android.media.MediaPlayer
 import java.io.File
 
-class AudioPlayer(private val inputFile: File) {
+class AudioPlayer(
+    private val inputFile: File,
+    private val playerProvider: () -> MediaPlayer = { MediaPlayer() }
+) {
 
     private var player: MediaPlayer? = null
 
     fun start() {
         try {
-            player = MediaPlayer().apply {
+            val instance = playerProvider().apply {
                 setDataSource(inputFile.absolutePath)
                 prepare()
                 start()
             }
+            player = instance
         } catch (e: Exception) {
             e.printStackTrace()
         }

--- a/audio/src/main/kotlin/com/siya/epistemophile/audio/AudioRecorder.kt
+++ b/audio/src/main/kotlin/com/siya/epistemophile/audio/AudioRecorder.kt
@@ -3,12 +3,15 @@ package com.siya.epistemophile.audio
 import android.media.MediaRecorder
 import java.io.File
 
-class AudioRecorder(private val outputFile: File) {
+class AudioRecorder(
+    private val outputFile: File,
+    private val recorderProvider: () -> MediaRecorder = { MediaRecorder() }
+) {
 
     private var recorder: MediaRecorder? = null
 
     fun start() {
-        recorder = MediaRecorder().apply {
+        val instance = recorderProvider().apply {
             setAudioSource(MediaRecorder.AudioSource.MIC)
             setOutputFormat(MediaRecorder.OutputFormat.MPEG_4)
             setAudioEncoder(MediaRecorder.AudioEncoder.AAC)
@@ -16,6 +19,7 @@ class AudioRecorder(private val outputFile: File) {
             prepare()
             start()
         }
+        recorder = instance
     }
 
     fun stop() {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ junit = "4.13.2"
 mockito = "5.11.0"
 mockito-kotlin = "5.0.0"
 robolectric = "4.11.1"
+robolectric-android-all = "14-robolectric-10818077"
 tap-target-view = "1.13.3"
 javax-inject = "1"
 
@@ -25,6 +26,7 @@ junit = { module = "junit:junit", version.ref = "junit" }
 mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
 mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version.ref = "mockito-kotlin" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
+robolectric-android-all = { module = "org.robolectric:android-all", version.ref = "robolectric-android-all" }
 coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
 coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }


### PR DESCRIPTION
## Summary
- inject media recorder/player providers so audio components can be unit-tested without Robolectric
- rewrite audio unit tests to use MockK-based verifications instead of Robolectric and tighten related imports in SaidIt tests
- add an explicit android-all runtime dependency for Robolectric-based tests and update supporting test classes

## Testing
- ./gradlew :audio:test

------
https://chatgpt.com/codex/tasks/task_b_68e177ce1f308323ac23fb4c7b6767d7