### PR TITLE
Fix overlapping frame iterator behavior

### DIFF
--- a/audio/src/main/kotlin/com/siya/epistemophile/audio/dsp/NormalizedFrameIterator.kt
+++ b/audio/src/main/kotlin/com/siya/epistemophile/audio/dsp/NormalizedFrameIterator.kt
@@ -16,6 +16,7 @@ class NormalizedFrameIterator(
     init {
         require(frameSize > 0) { "Frame size must be larger than zero." }
         require(shiftAmount > 0) { "Shift size must be larger than zero." }
+        require(shiftAmount <= frameSize) { "Shift size cannot exceed frame size." }
     }
 
     override fun hasNext(): Boolean {
@@ -51,7 +52,11 @@ class NormalizedFrameIterator(
             DoubleVector(data)
         } else {
             val previous = currentFrame!!.data.clone()
-            System.arraycopy(data, 0, previous, previous.size - shiftAmount, shiftAmount)
+            val preserved = previous.size - shiftAmount
+            if (preserved > 0) {
+                System.arraycopy(previous, shiftAmount, previous, 0, preserved)
+            }
+            System.arraycopy(data, 0, previous, preserved, data.size)
             DoubleVector(previous)
         }
         frameCounter++

--- a/audio/src/test/kotlin/com/siya/epistemophile/audio/dsp/NormalizedFrameIteratorTest.kt
+++ b/audio/src/test/kotlin/com/siya/epistemophile/audio/dsp/NormalizedFrameIteratorTest.kt
@@ -26,7 +26,7 @@ class NormalizedFrameIteratorTest {
         assertEquals(2, frames.size)
         val normalization = 0x7fff.toDouble()
         val expectedFirst = doubleArrayOf(0.0, 1000 / normalization, 2000 / normalization, 3000 / normalization)
-        val expectedSecond = doubleArrayOf(0.0, 1000 / normalization, 4000 / normalization, 5000 / normalization)
+        val expectedSecond = doubleArrayOf(2000 / normalization, 3000 / normalization, 4000 / normalization, 5000 / normalization)
         frames[0].forEachIndexed { index, value ->
             assertEquals(expectedFirst[index], value, 1e-3)
         }
@@ -50,5 +50,13 @@ class NormalizedFrameIteratorTest {
         assertEquals(2000 / 0x7fff.toDouble(), first[1], 1e-3)
         assertEquals(3000 / 0x7fff.toDouble(), first[2], 1e-3)
         assertEquals(0.0, first[3], 1e-6)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `iterator rejects shift larger than frame size`() {
+        val format = PcmAudioFormat.mono16BitSignedLittleEndian(8000)
+        val stream = PcmMonoInputStream(format, ByteArrayInputStream(ByteArray(0)))
+
+        NormalizedFrameIterator(stream, frameSize = 2, shiftAmount = 3, applyPadding = false)
     }
 }


### PR DESCRIPTION
## Summary
- ensure NormalizedFrameIterator enforces shift <= frame size and shifts existing samples forward
- update overlapping frame test expectations and cover invalid shift scenario

## Testing
- ./gradlew :audio:testDebugUnitTest --console plain
- ./gradlew :domain:test :data:test :features:recorder:test --console plain

------
https://chatgpt.com/codex/tasks/task_b_68e52d8f63448323b8cb2be7c5b20be8